### PR TITLE
読み取り専用のcookies.txtでyt-dlpがエラーになる問題を修正

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,4 +1,6 @@
 import os
+import shutil
+import tempfile
 
 ################################################################################
 # Botに関する設定
@@ -47,7 +49,25 @@ YTDL_EXTRACTOR_ARGS = {
 
 # cookies.txt が存在する場合のみ cookiefile を指定する
 # (存在しないパスを指定すると無駄な副作用やエラーの原因になるため)
-YTDL_COOKIEFILE = './cookies.txt' if os.path.isfile('./cookies.txt') else None
+#
+# yt-dlp は close() 時に cookiefile へクッキーを書き戻すため、読み取り専用で
+# マウントされた cookies.txt (docker-compose の :ro マウント) をそのまま渡すと
+# OCI 等の環境で OSError: Read-only file system になる。
+# 書き込み可能な一時ファイルへコピーして、そのコピーを使わせることで回避する。
+def _prepare_cookiefile():
+    source = './cookies.txt'
+    if not os.path.isfile(source):
+        return None
+    try:
+        fd, dest = tempfile.mkstemp(prefix='ytdl_cookies_', suffix='.txt')
+        os.close(fd)
+        shutil.copyfile(source, dest)
+        return dest
+    except OSError:
+        # コピーに失敗した場合は元ファイルを使用する (読み取り専用でなければ動作する)
+        return source
+
+YTDL_COOKIEFILE = _prepare_cookiefile()
 
 YTDL_OPTIONS = {
     'format': 'ba/b*[acodec!=none]/b*',


### PR DESCRIPTION
## 概要

OCI 等の環境で YouTube タイトルの autocomplete を実行した際、コンソールに `OSError: [Errno 30] Read-only file system: './cookies.txt'` が発生する問題を修正します。

## 原因

`docker-compose.yml` で `cookies.txt` を `:ro`（読み取り専用）でマウントしているが、yt-dlp は `close()` 時の `save_cookies()` でクッキーをファイルへ書き戻そうとするため、読み取り専用FSで `OSError` になっていました。

autocomplete に限らず、`cookiefile` を指定する全ての yt-dlp 呼び出し（`util.search_youtube` / `constants.YTDL_OPTIONS` / `cogs/downloader.py`）で起きうる問題です。

## 修正内容

`constants.py` で、起動時に読み取り専用の `./cookies.txt` を `tempfile` で作成した書き込み可能な一時ファイルへコピーし、yt-dlp にはそのコピーを `cookiefile` として渡すようにしました。

- yt-dlp がクッキーを書き戻しても一時ファイルへの書き込みとなりエラーになりません
- コピーに失敗した場合は従来どおり元ファイルにフォールバックします
- 全 yt-dlp 呼び出しが `const.YTDL_COOKIEFILE` を参照しているため、1箇所の修正で全て解消されます

🤖 Generated with [Claude Code](https://claude.com/claude-code)