### PR TITLE
DockerイメージのビルドをGitHub Packages(ghcr.io)へ移行

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.gitignore
+.github
+saves
+__pycache__
+**/__pycache__
+*.pyc
+.env
+.netrc
+cookies.txt
+docker-compose.override.yml
+README.md
+deploy.sh

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,38 @@
+name: Build and publish Docker image
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: ghcr.io/mimaraka/mashiro
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -68,10 +68,11 @@ GOOGLE_API_KEY=your-google-generative-ai-key   # optional; required only for Gem
 
 ### Run with Docker
 
-The bot runs alongside a [PO Token provider](https://github.com/Brainicism/bgutil-ytdlp-pot-provider) so that YouTube playback works from datacenter/VPS IPs (otherwise YouTube responds with "Sign in to confirm you're not a bot"). Use Docker Compose to start both services:
+The bot runs alongside a [PO Token provider](https://github.com/Brainicism/bgutil-ytdlp-pot-provider) so that YouTube playback works from datacenter/VPS IPs (otherwise YouTube responds with "Sign in to confirm you're not a bot"). The image is built by GitHub Actions and published to GitHub Packages (`ghcr.io/mimaraka/mashiro`). Use Docker Compose to pull it and start both services:
 
 ```bash
-docker compose up -d --build
+docker compose pull
+docker compose up -d
 ```
 
 #### YouTube cookies (recommended)

--- a/deploy.sh
+++ b/deploy.sh
@@ -86,9 +86,12 @@ log "設定ファイルをクローンへ反映します..."
 # .env: docker compose の env_file が参照 (クローン直下に必要)
 cp -f "$SCRIPT_DIR/.env" "$APP_DIR/.env"
 
-# .netrc: ビルド時に /bot/.netrc としてイメージへ取り込まれる
+# .netrc: docker-compose.yml が ./.netrc を /bot/.netrc に read-only マウントする
 if [ -f "$SCRIPT_DIR/.netrc" ]; then
     cp -f "$SCRIPT_DIR/.netrc" "$APP_DIR/.netrc"
+else
+    # 実体が無いと docker が空ディレクトリを作ってしまうため、空ファイルを用意する。
+    : > "$APP_DIR/.netrc"
 fi
 
 # cookies.txt: docker-compose.yml が ./cookies.txt をマウントする
@@ -116,8 +119,11 @@ YAML
 # 4. docker compose で起動
 ################################################################################
 
-log "docker compose で起動します (ビルド込み)..."
-( cd "$APP_DIR" && "${COMPOSE[@]}" up -d --build )
+log "GitHub Packages からイメージを取得します..."
+( cd "$APP_DIR" && "${COMPOSE[@]}" pull )
+
+log "docker compose で起動します..."
+( cd "$APP_DIR" && "${COMPOSE[@]}" up -d )
 
 log "起動しました。状態:"
 ( cd "$APP_DIR" && "${COMPOSE[@]}" ps )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mashiro:
-    build: .
+    image: ghcr.io/mimaraka/mashiro:latest
     env_file: .env
     environment:
       # PO Token生成サーバー(bgutil-provider)のベースURL
@@ -8,6 +8,8 @@ services:
     volumes:
       # ブラウザからエクスポートした cookies.txt をマウントする (無ければこの行を削除)
       - ./cookies.txt:/bot/cookies.txt:ro
+      # /dl 用の認証情報 .netrc をマウントする (無ければこの行を削除)
+      - ./.netrc:/bot/.netrc:ro
     depends_on:
       - bgutil-provider
     restart: unless-stopped


### PR DESCRIPTION
## 概要

DockerイメージのビルドをOCIホスト側のローカルビルドから、GitHub Actionsでビルドして GitHub Packages (`ghcr.io/mimaraka/mashiro`) へpushする方式へ移行します。OCI側はビルド済みイメージをpullするだけになり、ホストの負荷とデプロイ時間を削減できます。

## 変更内容

- **`.github/workflows/docker-publish.yml`**(新規): main へのpush / 手動実行でイメージをビルドし `ghcr.io/mimaraka/mashiro:latest` をpush(Buildx + GHAキャッシュ)
- **`.dockerignore`**(新規): `.git` / `saves` / `__pycache__` / 秘密ファイル等を除外
- **`docker-compose.yml`**: `build: .` → `image: ghcr.io/mimaraka/mashiro:latest`。`.netrc` を `:ro` マウントに追加(従来のビルド焼き込みの代替)
- **`deploy.sh`**: `.netrc` をマウント方式へ(無ければ空ファイル生成)、起動部を `up -d --build` → `pull` + `up -d` に変更
- **`README.md`**: Docker起動手順を更新

## 移行上の必須変更: `.netrc` のマウント化

従来 `.netrc`(gitignore対象の秘密情報)は `COPY . /bot` でビルド時に焼き込まれていました。GitHub側ビルドではビルドコンテキストに存在しないため、`cookies.txt` 同様に実行時マウントへ変更しています。

## デプロイ前の手動作業

- 初回push後、Packages設定で `mashiro` パッケージの visibility を **public** に変更(認証なしpullのため)

🤖 Generated with [Claude Code](https://claude.com/claude-code)